### PR TITLE
Add split and print_err function to split arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 a.out
 *.o
+*.swp
 vgcore.*
 hsh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS=-Wall -Werror -Wextra -pedantic -std=gnu89 -ggdb
 DEPS=hsh.h
-OBJ=hsh.o path.o
+OBJ=hsh.o path.o utils.o
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)

--- a/hsh.c
+++ b/hsh.c
@@ -22,7 +22,6 @@ int main(int ac, char *av[], char *envp[])
 	int status;
 
 	(void)ac;
-	(void)av;
 	do {
 		if (isatty(fileno(stdin)))
 		{
@@ -34,22 +33,23 @@ int main(int ac, char *av[], char *envp[])
 			break;
 		if (input != NULL)
 		{
-			bin = which(strtok(input, "\n"));
+			char **args = NULL;
+
+			args = split(strtok(input, "\n"), " ");
+			bin = which(*args);
 			if (bin != NULL)
 			{
 				child_pid = fork();
 				if (child_pid == 0)
 				{
-					/* TODO: use split to split arguments */
-					char *args[] = { NULL, NULL };
-
-					args[0] = bin;
-					if (execve(args[0], args, envp) == -1)
+					if (execve(bin, args, envp) == -1)
 						exit(EXIT_FAILURE);
 				}
 				else if (wait(&status) == -1)
 					break;
 			}
+			else
+				print_err(av[0], input, 1);
 		}
 	} while (1);
 	return (WEXITSTATUS(status));

--- a/hsh.h
+++ b/hsh.h
@@ -3,7 +3,8 @@
 
 extern char **environ;
 
-char **split(char *str, char delim);
+char **split(char *str, char *delim);
 char *which(const char *bin);
+void print_err(char *name, char *program, int line);
 
 #endif /* HSH_H */

--- a/path.c
+++ b/path.c
@@ -15,7 +15,7 @@
 char *which(const char *bin)
 {
 	char *path, *token, *filepath;
-	char **env = environ, *tmp;
+	char **env = environ, *tmp, **paths;
 	struct stat buf;
 
 	if (bin[0] == '/' || bin[0] == '.')
@@ -25,7 +25,6 @@ char *which(const char *bin)
 		else
 			return (NULL);
 	}
-
 	/* Extracts the PATH variable in envp */
 	while (*env)
 	{
@@ -35,26 +34,24 @@ char *which(const char *bin)
 			token = strtok(tmp, "=");
 			if (token == NULL)
 				break;
-			path = strtok(NULL, "=");
+			paths = split(strtok(NULL, "="), ":");
 			break;
 		}
 		env++;
 	}
-
 	/* Loop through dir paths in PATH */
-	while (1)
+	while (*paths)
 	{
-		token = strtok(path, ":");
-		if (token == NULL)
-			break;
-		filepath = malloc(strlen(token) + strlen(bin) + 2);
-		filepath = strcat(filepath, token);
+		filepath = malloc(strlen(*paths) + strlen(bin) + 2);
+		filepath = strcat(filepath, *paths);
 		filepath = strcat(filepath, "/");
 		filepath = strcat(filepath, bin);
 		if (stat(filepath, &buf) == 0)
 			return (filepath);
 
-		path = NULL;
+		free(filepath);
+		paths++;
 	}
+	free(paths);
 	return (NULL);
 }

--- a/path.c
+++ b/path.c
@@ -6,26 +6,15 @@
 #include <unistd.h>
 
 /**
- * which - returns path to a binary or NULL
+ * extract_path - extract directories from PATH variable.
  *
- * @bin: binary name
- *
- * Return: full path, NULL when not found
+ * Return: NULL turminated array
  */
-char *which(const char *bin)
+char **extract_path(void)
 {
-	char *path, *token, *filepath;
-	char **env = environ, *tmp, **paths;
-	struct stat buf;
-
-	if (bin[0] == '/' || bin[0] == '.')
-	{
-		if (stat(bin, &buf) == 0)
-			return (strdup(bin));
-		else
-			return (NULL);
-	}
-	/* Extracts the PATH variable in envp */
+	char **env = environ, *tmp, *token;
+	char **paths = { NULL };
+	/* Extracts the PATH variable in environ */
 	while (*env)
 	{
 		if (_strncmp(*env, "PATH", 4) == 0)
@@ -39,19 +28,65 @@ char *which(const char *bin)
 		}
 		env++;
 	}
+	return (paths);
+}
+
+/**
+ * free_paths - free paths from PATH
+ *
+ * @paths: NULL terminated array of paths
+ */
+void free_paths(char **paths)
+{
+	int i = 0;
+
+	if (paths)
+	{
+		while (paths[i])
+			free(paths[i++]);
+		free(paths);
+	}
+}
+
+/**
+ * which - returns path to a binary or NULL
+ *
+ * @bin: binary name
+ *
+ * Return: full path, NULL when not found
+ */
+char *which(const char *bin)
+{
+	char *filepath = NULL;
+	char **paths, **p;
+	struct stat buf;
+
+	if (*bin == '/' || *bin == '.')
+	{
+		if (stat(bin, &buf) == 0)
+			return (strdup(bin));
+		else
+			return (NULL);
+	}
+
+	paths = extract_path();
+	p = paths; /* for free */
+
 	/* Loop through dir paths in PATH */
 	while (*paths)
 	{
 		filepath = malloc(_strlen(*paths) + _strlen(bin) + 2);
-		filepath = _strcat(filepath, *paths);
+		filepath = _strcpy(filepath, *paths);
 		filepath = _strcat(filepath, "/");
 		filepath = _strcat(filepath, bin);
 		if (stat(filepath, &buf) == 0)
 			return (filepath);
 
 		free(filepath);
+		filepath = NULL;
 		paths++;
 	}
-	free(paths);
+	free_paths(p);
+
 	return (NULL);
 }

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,61 @@
+#include "hsh.h"
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * print_err - print "command not found" error
+ *
+ * @name: name of our shell ass passed in argv[0]
+ * @program: program name the program that was not found
+ * @line: line number if it was piped
+ */
+void print_err(char *name, char *program, int line)
+{
+	const char *err_str = ": command not found\n";
+
+	(void)line;
+	write(STDERR_FILENO, name, strlen(name));
+	if (isatty(fileno(stdin)))
+		write(STDERR_FILENO, ": ", strlen(": "));
+	else
+		write(STDERR_FILENO, ": line 1: ", strlen(": line 1: "));
+	write(STDERR_FILENO, program, strlen(program));
+	write(STDERR_FILENO, err_str, strlen(err_str));
+	fflush(stderr);
+	if (isatty(fileno(stdin)) == 0)
+		exit(127);
+}
+
+/**
+ * split - splits a string using a delimiter and returns a
+ * malloced array pointer with the last value set to NULL.
+ *
+ * @str: string to split.
+ * @delim: elimiting character to use.
+ *
+ * Return: malloced array pointer with the last value set to NULL.
+ */
+char **split(char *str, char *delim)
+{
+	char **arr = { NULL };
+	char *token;
+	int i = 0;
+
+	/* Loop through the string */
+	while (1)
+	{
+		token = strtok(str, delim);
+		if (token == NULL)
+			break;
+		arr = realloc(arr, sizeof(char *) * (i + 2));
+		arr[i] = strdup(token);
+
+		str = NULL;
+		i++;
+	}
+	arr[i] = NULL;
+
+	return (arr);
+}


### PR DESCRIPTION
`split` to split command arguments passed by user

`print_err` to print error in a format similar to `/bin/sh`

closes #2 